### PR TITLE
Add AI assistant with keyword matching and Gemini integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,19 +46,26 @@ dependencies {
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac-aarch64'
     implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
+
+    implementation 'dev.langchain4j:langchain4j:0.36.2'
+    implementation 'dev.langchain4j:langchain4j-google-ai-gemini:0.36.2'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 

--- a/docs/AI-Integration-Report.md
+++ b/docs/AI-Integration-Report.md
@@ -1,0 +1,84 @@
+# CoursePilot AI Assistant — Setup & Features
+
+## Setup
+
+### Basic (No API key needed)
+The app includes built-in keyword matching that provides instant help responses. No setup required — just type naturally.
+
+### Advanced (Google Gemini AI)
+To enable AI-powered conversational assistance:
+
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey) and get a free API key
+2. In CoursePilot, click **AI > AI Settings** in the menu bar
+3. Paste your API key and click **Save**
+
+The key is saved to your preferences and persists across sessions.
+
+## How It Works
+
+When you type something that isn't a recognized command, CoursePilot uses a three-tier approach:
+
+```
+User input (not a valid command)
+    |
+    v
+1. Valid command? --> Execute normally
+    |  (no)
+    v
+2. Keyword match? --> Show usage/help instantly
+    |  (no match)
+    v
+3. Gemini configured? --> Ask Gemini AI (background thread)
+    |  (no)
+    v
+4. Fallback message --> "Type 'help' to see available commands"
+```
+
+### Tier 1: Command Execution
+Standard commands (`add`, `edit`, `delete`, etc.) are executed normally.
+
+### Tier 2: Keyword Matching (Instant, No Network)
+If the input contains recognizable keywords, the app returns the relevant command usage:
+
+| You type | Response |
+|---|---|
+| how can I get started? | Getting started guide |
+| how do I add a student? | `add` command usage and syntax |
+| how to delete | `delete` command usage |
+| how to search | `find` command usage |
+| show me all | `list` command usage |
+
+### Tier 3: Gemini AI (Requires API Key)
+If no keyword matches and a Gemini API key is configured, the question is sent to Google Gemini for a conversational response. Features:
+- Conversation memory (last 10 turns per session)
+- Runs on a background thread (UI stays responsive)
+- Knows all CoursePilot commands and can give examples
+
+### Tier 4: Fallback
+If nothing matches and Gemini isn't configured, a helpful fallback message is shown.
+
+## Configuration
+
+Click **AI > AI Settings** in the menu bar to:
+- Open Google AI Studio to get an API key
+- Enter/save your API key
+- Clear your API key to disable AI features
+
+The API key is stored in `preferences.json`.
+
+## Architecture
+
+### Key Files
+
+| File | Purpose |
+|---|---|
+| `logic/ai/KeywordMatcher.java` | Maps keywords to command MESSAGE_USAGE responses |
+| `logic/ai/NaturalLanguageParser.java` | Three-tier orchestrator: keyword → Gemini → fallback |
+| `logic/ai/ChatModelFactory.java` | Creates LangChain4j Gemini model from API key |
+| `ui/AiSettingsWindow.java` | UI for API key configuration |
+| `ui/MainWindow.java` | Routes unknown commands to AI handler |
+
+### Dependencies
+
+- **LangChain4j 0.36.2** — LLM framework with chat memory
+- **LangChain4j Google AI Gemini 0.36.2** — Gemini API connector

--- a/src/main/java/seedu/coursepilot/MainApp.java
+++ b/src/main/java/seedu/coursepilot/MainApp.java
@@ -172,6 +172,10 @@ public class MainApp extends Application {
     public void start(Stage primaryStage) {
         logger.info("Starting CoursePilot " + MainApp.VERSION);
         ui.start(primaryStage);
+        if (ui instanceof UiManager) {
+            UiManager uiManager = (UiManager) ui;
+            uiManager.setHostServices(getHostServices());
+        }
     }
 
     @Override

--- a/src/main/java/seedu/coursepilot/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/coursepilot/commons/util/JsonUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -37,7 +38,9 @@ public class JsonUtil {
             .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
             .registerModule(new SimpleModule("SimpleModule")
                     .addSerializer(Level.class, new ToStringSerializer())
-                    .addDeserializer(Level.class, new LevelDeserializer(Level.class)));
+                    .addDeserializer(Level.class, new LevelDeserializer(Level.class))
+                    .addSerializer(Path.class, new ToStringSerializer())
+                    .addDeserializer(Path.class, new PathDeserializer(Path.class)));
 
     static <T> void serializeObjectToJsonFile(Path jsonFile, T objectToSerialize) throws IOException {
         FileUtil.writeToFile(jsonFile, toJsonString(objectToSerialize));
@@ -138,6 +141,26 @@ public class JsonUtil {
         @Override
         public Class<Level> handledType() {
             return Level.class;
+        }
+    }
+
+    /**
+     * Deserializes a JSON string into a {@code Path}, preserving relative paths.
+     */
+    private static class PathDeserializer extends FromStringDeserializer<Path> {
+
+        protected PathDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        protected Path _deserialize(String value, DeserializationContext ctxt) {
+            return Paths.get(value);
+        }
+
+        @Override
+        public Class<Path> handledType() {
+            return Path.class;
         }
     }
 

--- a/src/main/java/seedu/coursepilot/logic/Logic.java
+++ b/src/main/java/seedu/coursepilot/logic/Logic.java
@@ -59,4 +59,14 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the Gemini API key from user prefs.
+     */
+    String getGeminiApiKey();
+
+    /**
+     * Sets the Gemini API key in user prefs.
+     */
+    void setGeminiApiKey(String apiKey);
 }

--- a/src/main/java/seedu/coursepilot/logic/LogicManager.java
+++ b/src/main/java/seedu/coursepilot/logic/LogicManager.java
@@ -105,4 +105,14 @@ public class LogicManager implements Logic {
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }
+
+    @Override
+    public String getGeminiApiKey() {
+        return model.getGeminiApiKey();
+    }
+
+    @Override
+    public void setGeminiApiKey(String apiKey) {
+        model.setGeminiApiKey(apiKey);
+    }
 }

--- a/src/main/java/seedu/coursepilot/logic/ai/ChatModelFactory.java
+++ b/src/main/java/seedu/coursepilot/logic/ai/ChatModelFactory.java
@@ -1,0 +1,39 @@
+package seedu.coursepilot.logic.ai;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import seedu.coursepilot.commons.core.LogsCenter;
+
+/**
+ * Factory for creating LangChain4j chat model instances configured for CoursePilot.
+ */
+public class ChatModelFactory {
+
+    private static final Logger logger = LogsCenter.getLogger(ChatModelFactory.class);
+    private static final String DEFAULT_MODEL_NAME = "gemini-2.0-flash";
+
+    /**
+     * Creates a ChatLanguageModel using the Google Gemini API with the given key.
+     *
+     * @param apiKey The Google Gemini API key.
+     * @return An Optional containing the model if creation succeeded, or empty on failure.
+     */
+    public static Optional<ChatLanguageModel> createGeminiModel(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            ChatLanguageModel model = GoogleAiGeminiChatModel.builder()
+                    .apiKey(apiKey)
+                    .modelName(DEFAULT_MODEL_NAME)
+                    .build();
+            return Optional.of(model);
+        } catch (Exception e) {
+            logger.info("Failed to create Gemini model: " + e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/seedu/coursepilot/logic/ai/KeywordMatcher.java
+++ b/src/main/java/seedu/coursepilot/logic/ai/KeywordMatcher.java
@@ -1,0 +1,86 @@
+package seedu.coursepilot.logic.ai;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import seedu.coursepilot.logic.commands.AddCommand;
+import seedu.coursepilot.logic.commands.ClearCommand;
+import seedu.coursepilot.logic.commands.DeleteCommand;
+import seedu.coursepilot.logic.commands.EditCommand;
+import seedu.coursepilot.logic.commands.ExitCommand;
+import seedu.coursepilot.logic.commands.FindCommand;
+import seedu.coursepilot.logic.commands.HelpCommand;
+import seedu.coursepilot.logic.commands.ListCommand;
+import seedu.coursepilot.logic.commands.SelectCommand;
+
+/**
+ * Matches user input against known keywords and returns hardcoded help responses.
+ */
+public class KeywordMatcher {
+
+    private static final String GETTING_STARTED_RESPONSE =
+            "Welcome to CoursePilot! Here's how to get started:\n"
+            + "1. Use 'add -student' to add students\n"
+            + "2. Use 'add -tutorial' to add tutorials\n"
+            + "3. Use 'list -student' or 'list -tutorial' to view them\n"
+            + "4. Use 'select TUTORIAL_CODE' to select a tutorial\n"
+            + "5. Use 'find' to search for students\n"
+            + "6. Type 'help' to open the user guide";
+
+    private static final Map<String[], String> KEYWORD_RESPONSES = new LinkedHashMap<>();
+
+    static {
+        KEYWORD_RESPONSES.put(
+                new String[]{"get started", "start", "begin", "new here", "tutorial"},
+                GETTING_STARTED_RESPONSE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"add", "create", "new student", "new tutorial"},
+                AddCommand.MESSAGE_USAGE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"edit", "change", "update", "modify"},
+                EditCommand.MESSAGE_USAGE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"delete", "remove", "drop"},
+                DeleteCommand.MESSAGE_USAGE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"find", "search", "look for"},
+                FindCommand.MESSAGE_USAGE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"list", "show", "display", "all"},
+                ListCommand.MESSAGE_USAGE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"select", "choose", "pick"},
+                SelectCommand.MESSAGE_USAGE);
+        KEYWORD_RESPONSES.put(
+                new String[]{"clear", "reset", "erase"},
+                ClearCommand.COMMAND_WORD + ": Clears all entries from CoursePilot.");
+        KEYWORD_RESPONSES.put(
+                new String[]{"exit", "quit", "close"},
+                ExitCommand.COMMAND_WORD + ": Exits the application.");
+        KEYWORD_RESPONSES.put(
+                new String[]{"help", "guide", "instructions", "commands"},
+                HelpCommand.MESSAGE_USAGE + "\n\nAvailable commands: add, edit, delete, find,"
+                + " list, select, clear, help, exit");
+    }
+
+    /**
+     * Attempts to match user input against known keywords and return a helpful response.
+     *
+     * @param userInput The user's natural language input.
+     * @return An Optional containing the matched response, or empty if no match found.
+     */
+    public Optional<String> match(String userInput) {
+        String lower = userInput.strip().toLowerCase();
+
+        for (Map.Entry<String[], String> entry : KEYWORD_RESPONSES.entrySet()) {
+            for (String keyword : entry.getKey()) {
+                if (lower.contains(keyword)) {
+                    return Optional.of(entry.getValue());
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/seedu/coursepilot/logic/ai/NaturalLanguageParser.java
+++ b/src/main/java/seedu/coursepilot/logic/ai/NaturalLanguageParser.java
@@ -1,0 +1,144 @@
+package seedu.coursepilot.logic.ai;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import seedu.coursepilot.commons.core.LogsCenter;
+
+/**
+ * Provides AI-powered assistance using a three-tier approach:
+ * 1. Keyword matching against known command usage messages
+ * 2. Gemini API for conversational responses (when API key is configured)
+ * 3. Fallback message directing users to 'help'
+ */
+public class NaturalLanguageParser {
+
+    private static final Logger logger = LogsCenter.getLogger(NaturalLanguageParser.class);
+
+    private static final String CHAT_SYSTEM_PROMPT =
+            "You are CoursePilot Assistant, a helpful chatbot for a student/tutorial management app.\n"
+            + "Answer questions about how to use the app concisely.\n\n"
+            + "Available commands:\n"
+            + "- add -student n/NAME p/PHONE e/EMAIL m/MATRIC [t/TAG]... : Add a student\n"
+            + "- add -tutorial TUTORIAL_CODE : Add a tutorial\n"
+            + "- edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [m/MATRIC] [t/TAG]... : Edit a student\n"
+            + "- delete -student INDEX : Delete a student\n"
+            + "- delete -tutorial TUTORIAL_CODE : Delete a tutorial\n"
+            + "- find KEYWORD [MORE_KEYWORDS] : Search students by name\n"
+            + "- find /phone PHONE_PREFIX : Search by phone\n"
+            + "- find /email EMAIL_KEYWORD : Search by email\n"
+            + "- find /matric MATRIC_PREFIX : Search by matric number\n"
+            + "- list -student : Show all students\n"
+            + "- list -tutorial : Show all tutorials\n"
+            + "- select TUTORIAL_CODE : Select a tutorial\n"
+            + "- clear : Remove all data\n"
+            + "- help : Show help\n"
+            + "- exit : Close the app\n\n"
+            + "Prefixes: n/=name, p/=phone, e/=email, m/=matric, t/=tag.\n"
+            + "If the user asks how to do something, explain which command to use with an example.";
+
+    private static final String FALLBACK_MESSAGE =
+            "I couldn't find a specific answer. Type 'help' to see all available commands,"
+            + " or try asking about a specific command like 'add', 'edit', 'delete', 'find', or 'list'.";
+
+    private final KeywordMatcher keywordMatcher;
+    private ChatLanguageModel geminiModel;
+    private final ChatMemory chatMemory;
+
+    /**
+     * Creates a NaturalLanguageParser with no Gemini model (keyword matching only).
+     */
+    public NaturalLanguageParser() {
+        this.keywordMatcher = new KeywordMatcher();
+        this.geminiModel = null;
+        this.chatMemory = MessageWindowChatMemory.withMaxMessages(20);
+    }
+
+    /**
+     * Creates a NaturalLanguageParser with a custom keyword matcher and model (for testing).
+     */
+    NaturalLanguageParser(KeywordMatcher keywordMatcher, ChatLanguageModel geminiModel) {
+        this.keywordMatcher = keywordMatcher;
+        this.geminiModel = geminiModel;
+        this.chatMemory = MessageWindowChatMemory.withMaxMessages(20);
+    }
+
+    /**
+     * Sets the Gemini API key, creating or clearing the Gemini model.
+     */
+    public void setGeminiApiKey(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
+            this.geminiModel = null;
+            logger.info("Gemini API key cleared.");
+        } else {
+            Optional<ChatLanguageModel> model = ChatModelFactory.createGeminiModel(apiKey);
+            this.geminiModel = model.orElse(null);
+            if (this.geminiModel != null) {
+                logger.info("Gemini model configured successfully.");
+            }
+        }
+    }
+
+    /**
+     * Returns true if the Gemini model is configured and available.
+     */
+    public boolean isGeminiAvailable() {
+        return geminiModel != null;
+    }
+
+    /**
+     * Handles unknown user input through a three-tier approach:
+     * 1. Try keyword matching first (instant, no network)
+     * 2. If no keyword match and Gemini is available, ask Gemini
+     * 3. Otherwise return a fallback message
+     *
+     * @param userInput The user's input that was not recognized as a valid command.
+     * @return A helpful response string.
+     */
+    public String handleUnknownInput(String userInput) {
+        // Tier 1: Keyword matching
+        Optional<String> keywordResponse = keywordMatcher.match(userInput);
+        if (keywordResponse.isPresent()) {
+            return keywordResponse.get();
+        }
+
+        // Tier 2: Gemini API
+        if (geminiModel != null) {
+            return chatWithGemini(userInput);
+        }
+
+        // Tier 3: Fallback
+        return FALLBACK_MESSAGE;
+    }
+
+    /**
+     * Sends a conversational question to Gemini and returns the response.
+     * Maintains conversation history via ChatMemory.
+     */
+    private String chatWithGemini(String userInput) {
+        try {
+            chatMemory.add(UserMessage.from(userInput));
+
+            List<ChatMessage> messages = new ArrayList<>();
+            messages.add(SystemMessage.from(CHAT_SYSTEM_PROMPT));
+            messages.addAll(chatMemory.messages());
+
+            String responseText = geminiModel.generate(messages).content().text();
+
+            chatMemory.add(AiMessage.from(responseText));
+            return responseText;
+        } catch (Exception e) {
+            logger.info("Gemini API error: " + e.getMessage());
+            return "AI error: " + e.getMessage() + "\n" + FALLBACK_MESSAGE;
+        }
+    }
+}

--- a/src/main/java/seedu/coursepilot/model/Model.java
+++ b/src/main/java/seedu/coursepilot/model/Model.java
@@ -102,4 +102,10 @@ public interface Model {
 
     /** Clears the current operating tutorial. */
     void clearCurrentOperatingTutorial();
+
+    /** Returns the Gemini API key from user prefs. */
+    String getGeminiApiKey();
+
+    /** Sets the Gemini API key in user prefs. */
+    void setGeminiApiKey(String apiKey);
 }

--- a/src/main/java/seedu/coursepilot/model/ModelManager.java
+++ b/src/main/java/seedu/coursepilot/model/ModelManager.java
@@ -75,6 +75,16 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public String getGeminiApiKey() {
+        return userPrefs.getGeminiApiKey();
+    }
+
+    @Override
+    public void setGeminiApiKey(String apiKey) {
+        userPrefs.setGeminiApiKey(apiKey);
+    }
+
+    @Override
     public Path getCoursePilotFilePath() {
         return userPrefs.getCoursePilotFilePath();
     }

--- a/src/main/java/seedu/coursepilot/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/coursepilot/model/ReadOnlyUserPrefs.java
@@ -13,4 +13,6 @@ public interface ReadOnlyUserPrefs {
 
     Path getCoursePilotFilePath();
 
+    String getGeminiApiKey();
+
 }

--- a/src/main/java/seedu/coursepilot/model/UserPrefs.java
+++ b/src/main/java/seedu/coursepilot/model/UserPrefs.java
@@ -15,6 +15,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
     private Path coursePilotFilePath = Paths.get("data" , "addressbook.json");
+    private String geminiApiKey = "";
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -36,6 +37,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
         setCoursePilotFilePath(newUserPrefs.getCoursePilotFilePath());
+        setGeminiApiKey(newUserPrefs.getGeminiApiKey());
     }
 
     public GuiSettings getGuiSettings() {
@@ -56,6 +58,14 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.coursePilotFilePath = coursePilotFilePath;
     }
 
+    public String getGeminiApiKey() {
+        return geminiApiKey;
+    }
+
+    public void setGeminiApiKey(String geminiApiKey) {
+        this.geminiApiKey = geminiApiKey == null ? "" : geminiApiKey;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -69,12 +79,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
         UserPrefs otherUserPrefs = (UserPrefs) other;
         return guiSettings.equals(otherUserPrefs.guiSettings)
-                && coursePilotFilePath.equals(otherUserPrefs.coursePilotFilePath);
+                && coursePilotFilePath.equals(otherUserPrefs.coursePilotFilePath)
+                && Objects.equals(geminiApiKey, otherUserPrefs.geminiApiKey);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, coursePilotFilePath);
+        return Objects.hash(guiSettings, coursePilotFilePath, geminiApiKey);
     }
 
     @Override
@@ -82,6 +93,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
         sb.append("\nLocal data file location : " + coursePilotFilePath);
+        sb.append("\nGemini API key : " + (geminiApiKey.isEmpty() ? "not set" : "configured"));
         return sb.toString();
     }
 

--- a/src/main/java/seedu/coursepilot/ui/AiSettingsWindow.java
+++ b/src/main/java/seedu/coursepilot/ui/AiSettingsWindow.java
@@ -1,0 +1,126 @@
+package seedu.coursepilot.ui;
+
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import javafx.application.HostServices;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+import seedu.coursepilot.commons.core.LogsCenter;
+
+/**
+ * Controller for the AI Settings window where users can configure their Gemini API key.
+ */
+public class AiSettingsWindow extends UiPart<Stage> {
+
+    public static final String GEMINI_URL = "https://aistudio.google.com/apikey";
+
+    private static final Logger logger = LogsCenter.getLogger(AiSettingsWindow.class);
+    private static final String FXML = "AiSettingsWindow.fxml";
+
+    private final Consumer<String> onApiKeySaved;
+    private final HostServices hostServices;
+
+    @FXML
+    private TextField apiKeyField;
+
+    @FXML
+    private Label statusLabel;
+
+    /**
+     * Creates a new AiSettingsWindow.
+     *
+     * @param root Stage to use as the root.
+     * @param onApiKeySaved Callback invoked when the user saves an API key.
+     * @param hostServices HostServices for opening URLs in browser.
+     * @param currentKey The current API key to pre-fill, or empty string.
+     */
+    public AiSettingsWindow(Stage root, Consumer<String> onApiKeySaved,
+                            HostServices hostServices, String currentKey) {
+        super(FXML, root);
+        this.onApiKeySaved = onApiKeySaved;
+        this.hostServices = hostServices;
+        if (currentKey != null && !currentKey.isBlank()) {
+            apiKeyField.setText(currentKey);
+            statusLabel.setText("AI features are enabled.");
+            statusLabel.setStyle("-fx-text-fill: #4CAF50;");
+        }
+    }
+
+    /**
+     * Creates a new AiSettingsWindow with a new Stage.
+     */
+    public AiSettingsWindow(Consumer<String> onApiKeySaved,
+                            HostServices hostServices, String currentKey) {
+        this(new Stage(), onApiKeySaved, hostServices, currentKey);
+    }
+
+    /**
+     * Shows the AI settings window.
+     */
+    public void show() {
+        logger.fine("Showing AI settings window.");
+        getRoot().show();
+        getRoot().centerOnScreen();
+    }
+
+    /**
+     * Returns true if the window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Hides the window.
+     */
+    public void hide() {
+        getRoot().hide();
+    }
+
+    /**
+     * Focuses on the window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
+
+    /**
+     * Opens the Google AI Studio link in the default browser.
+     */
+    @FXML
+    private void openGeminiLink() {
+        if (hostServices != null) {
+            hostServices.showDocument(GEMINI_URL);
+        }
+    }
+
+    /**
+     * Saves the API key and notifies the callback.
+     */
+    @FXML
+    private void handleSave() {
+        String apiKey = apiKeyField.getText().strip();
+        if (apiKey.isEmpty()) {
+            statusLabel.setText("Please enter an API key.");
+            statusLabel.setStyle("-fx-text-fill: #FF5252;");
+            return;
+        }
+        onApiKeySaved.accept(apiKey);
+        statusLabel.setText("API key saved. AI features are now enabled.");
+        statusLabel.setStyle("-fx-text-fill: #4CAF50;");
+    }
+
+    /**
+     * Clears the API key and notifies the callback.
+     */
+    @FXML
+    private void handleClear() {
+        apiKeyField.setText("");
+        onApiKeySaved.accept("");
+        statusLabel.setText("API key cleared. AI features are disabled.");
+        statusLabel.setStyle("-fx-text-fill: #FF9800;");
+    }
+}

--- a/src/main/java/seedu/coursepilot/ui/CommandBox.java
+++ b/src/main/java/seedu/coursepilot/ui/CommandBox.java
@@ -70,6 +70,20 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
+     * Sets the text in the command box.
+     */
+    public void setCommandText(String text) {
+        commandTextField.setText(text);
+    }
+
+    /**
+     * Returns the current text in the command box.
+     */
+    public String getCommandText() {
+        return commandTextField.getText();
+    }
+
+    /**
      * Represents a function that can execute commands.
      */
     @FunctionalInterface

--- a/src/main/java/seedu/coursepilot/ui/MainWindow.java
+++ b/src/main/java/seedu/coursepilot/ui/MainWindow.java
@@ -1,7 +1,10 @@
 package seedu.coursepilot.ui;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
+import javafx.application.HostServices;
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
@@ -13,6 +16,7 @@ import javafx.stage.Stage;
 import seedu.coursepilot.commons.core.GuiSettings;
 import seedu.coursepilot.commons.core.LogsCenter;
 import seedu.coursepilot.logic.Logic;
+import seedu.coursepilot.logic.ai.NaturalLanguageParser;
 import seedu.coursepilot.logic.commands.CommandResult;
 import seedu.coursepilot.logic.commands.exceptions.CommandException;
 import seedu.coursepilot.logic.parser.exceptions.ParseException;
@@ -36,6 +40,10 @@ public class MainWindow extends UiPart<Stage> {
     private TutorialDetailsPanel tutorialDetailsPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+    private AiSettingsWindow aiSettingsWindow;
+    private CommandBox commandBox;
+    private final NaturalLanguageParser nlParser = new NaturalLanguageParser();
+    private HostServices hostServices;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -71,6 +79,19 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+        // Initialize Gemini if API key is configured
+        String savedKey = logic.getGeminiApiKey();
+        if (savedKey != null && !savedKey.isBlank()) {
+            nlParser.setGeminiApiKey(savedKey);
+        }
+    }
+
+    /**
+     * Sets the HostServices for opening URLs in the browser.
+     */
+    public void setHostServices(HostServices hostServices) {
+        this.hostServices = hostServices;
     }
 
     public Stage getPrimaryStage() {
@@ -144,7 +165,7 @@ public class MainWindow extends UiPart<Stage> {
             logic.getCurrentOperatingTutorialProperty());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 
@@ -204,7 +225,32 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Opens the AI settings window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handleAiSettings() {
+        if (aiSettingsWindow == null || !aiSettingsWindow.isShowing()) {
+            String currentKey = logic.getGeminiApiKey();
+            aiSettingsWindow = new AiSettingsWindow(
+                    this::onApiKeySaved, hostServices,
+                    currentKey != null ? currentKey : "");
+            aiSettingsWindow.show();
+        } else {
+            aiSettingsWindow.focus();
+        }
+    }
+
+    /**
+     * Callback when the user saves or clears the Gemini API key.
+     */
+    private void onApiKeySaved(String apiKey) {
+        logic.setGeminiApiKey(apiKey);
+        nlParser.setGeminiApiKey(apiKey);
+    }
+
+    /**
      * Executes the command and returns the result.
+     * If the command is unknown, falls back to AI assistance.
      *
      * @see seedu.coursepilot.logic.Logic#execute(String)
      */
@@ -225,10 +271,46 @@ public class MainWindow extends UiPart<Stage> {
             updateCenterPanel(commandText);
 
             return commandResult;
-        } catch (CommandException | ParseException e) {
+        } catch (ParseException e) {
+            if (e.getMessage().contains("Unknown command")) {
+                handleUnknownCommand(commandText);
+                throw e;
+            }
             logger.info("An error occurred while executing command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;
+        } catch (CommandException e) {
+            logger.info("An error occurred while executing command: " + commandText);
+            resultDisplay.setFeedbackToUser(e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Handles an unknown command by trying keyword matching, then Gemini API.
+     * Keyword matching is instant; Gemini runs on a background thread.
+     */
+    private void handleUnknownCommand(String userInput) {
+        if (nlParser.isGeminiAvailable()) {
+            // Check keyword match first (instant)
+            Optional<String> keywordMatch =
+                    new seedu.coursepilot.logic.ai.KeywordMatcher().match(userInput);
+            if (keywordMatch.isPresent()) {
+                resultDisplay.setFeedbackToUser(keywordMatch.get());
+                return;
+            }
+            // Fall through to Gemini on background thread
+            resultDisplay.setFeedbackToUser("Asking AI assistant...");
+            Thread aiThread = new Thread(() -> {
+                String response = nlParser.handleUnknownInput(userInput);
+                Platform.runLater(() -> resultDisplay.setFeedbackToUser(response));
+            });
+            aiThread.setDaemon(true);
+            aiThread.start();
+        } else {
+            // No Gemini — use keyword matcher with fallback
+            String response = nlParser.handleUnknownInput(userInput);
+            resultDisplay.setFeedbackToUser(response);
         }
     }
 }

--- a/src/main/java/seedu/coursepilot/ui/UiManager.java
+++ b/src/main/java/seedu/coursepilot/ui/UiManager.java
@@ -2,6 +2,7 @@ package seedu.coursepilot.ui;
 
 import java.util.logging.Logger;
 
+import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -30,6 +31,15 @@ public class UiManager implements Ui {
      */
     public UiManager(Logic logic) {
         this.logic = logic;
+    }
+
+    /**
+     * Sets the HostServices for opening URLs in the browser.
+     */
+    public void setHostServices(HostServices hostServices) {
+        if (mainWindow != null) {
+            mainWindow.setHostServices(hostServices);
+        }
     }
 
     @Override

--- a/src/main/resources/view/AiSettingsWindow.fxml
+++ b/src/main/resources/view/AiSettingsWindow.fxml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
+
+<fx:root resizable="false" title="AI Settings" type="javafx.stage.Stage"
+         xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <icons>
+    <Image url="@/images/help_icon.png" />
+  </icons>
+  <scene>
+    <Scene>
+      <stylesheets>
+        <URL value="@DarkTheme.css" />
+      </stylesheets>
+
+      <VBox spacing="10" prefWidth="550">
+        <padding>
+          <Insets top="15" right="15" bottom="15" left="15" />
+        </padding>
+
+        <Label text="AI Assistant Settings" style="-fx-font-size: 16; -fx-font-weight: bold;" />
+
+        <Label text="Configure a Google Gemini API key to enable AI-powered assistance."
+               wrapText="true" />
+
+        <Label text="Get your free API key from:" />
+        <Hyperlink fx:id="geminiLink" text="Google AI Studio"
+                   onAction="#openGeminiLink" />
+
+        <Label text="API Key:" />
+        <HBox spacing="10" alignment="CENTER_LEFT">
+          <TextField fx:id="apiKeyField" promptText="Enter your Gemini API key"
+                     HBox.hgrow="ALWAYS" />
+          <Button fx:id="saveButton" text="Save" onAction="#handleSave"
+                  minWidth="70" />
+          <Button fx:id="clearButton" text="Clear" onAction="#handleClear"
+                  minWidth="70" />
+        </HBox>
+
+        <Label fx:id="statusLabel" text="" wrapText="true" />
+      </VBox>
+    </Scene>
+  </scene>
+</fx:root>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -31,6 +31,9 @@
           <Menu mnemonicParsing="false" text="Help">
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
           </Menu>
+          <Menu mnemonicParsing="false" text="AI">
+            <MenuItem mnemonicParsing="false" onAction="#handleAiSettings" text="AI Settings" />
+          </Menu>
         </MenuBar>
 
         <SplitPane VBox.vgrow="ALWAYS" dividerPositions="0.25" styleClass="pane-with-border">

--- a/src/test/java/seedu/coursepilot/logic/ai/KeywordMatcherTest.java
+++ b/src/test/java/seedu/coursepilot/logic/ai/KeywordMatcherTest.java
@@ -1,0 +1,77 @@
+package seedu.coursepilot.logic.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.coursepilot.logic.commands.AddCommand;
+import seedu.coursepilot.logic.commands.DeleteCommand;
+import seedu.coursepilot.logic.commands.EditCommand;
+import seedu.coursepilot.logic.commands.FindCommand;
+import seedu.coursepilot.logic.commands.ListCommand;
+
+/**
+ * Unit tests for {@link KeywordMatcher}.
+ */
+public class KeywordMatcherTest {
+
+    private final KeywordMatcher matcher = new KeywordMatcher();
+
+    @Test
+    public void match_addKeyword_returnsAddUsage() {
+        Optional<String> result = matcher.match("how do I add a student?");
+        assertTrue(result.isPresent());
+        assertEquals(AddCommand.MESSAGE_USAGE, result.get());
+    }
+
+    @Test
+    public void match_deleteKeyword_returnsDeleteUsage() {
+        Optional<String> result = matcher.match("how to delete someone");
+        assertTrue(result.isPresent());
+        assertEquals(DeleteCommand.MESSAGE_USAGE, result.get());
+    }
+
+    @Test
+    public void match_editKeyword_returnsEditUsage() {
+        Optional<String> result = matcher.match("how to edit a student");
+        assertTrue(result.isPresent());
+        assertEquals(EditCommand.MESSAGE_USAGE, result.get());
+    }
+
+    @Test
+    public void match_findKeyword_returnsFindUsage() {
+        Optional<String> result = matcher.match("how to search for someone");
+        assertTrue(result.isPresent());
+        assertEquals(FindCommand.MESSAGE_USAGE, result.get());
+    }
+
+    @Test
+    public void match_listKeyword_returnsListUsage() {
+        Optional<String> result = matcher.match("show me all students");
+        assertTrue(result.isPresent());
+        assertEquals(ListCommand.MESSAGE_USAGE, result.get());
+    }
+
+    @Test
+    public void match_getStarted_returnsGettingStarted() {
+        Optional<String> result = matcher.match("how can I get started?");
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("Welcome to CoursePilot"));
+    }
+
+    @Test
+    public void match_noMatch_returnsEmpty() {
+        Optional<String> result = matcher.match("what is the meaning of life");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void match_caseInsensitive_works() {
+        Optional<String> result = matcher.match("How Do I ADD a student");
+        assertTrue(result.isPresent());
+        assertEquals(AddCommand.MESSAGE_USAGE, result.get());
+    }
+}

--- a/src/test/java/seedu/coursepilot/logic/ai/NaturalLanguageParserTest.java
+++ b/src/test/java/seedu/coursepilot/logic/ai/NaturalLanguageParserTest.java
@@ -1,0 +1,100 @@
+package seedu.coursepilot.logic.ai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.output.Response;
+
+/**
+ * Unit tests for {@link NaturalLanguageParser}.
+ */
+public class NaturalLanguageParserTest {
+
+    private static ChatLanguageModel stubModel(String responseText) {
+        return new ChatLanguageModel() {
+            @Override
+            public Response<AiMessage> generate(List<ChatMessage> messages) {
+                return new Response<>(AiMessage.from(responseText));
+            }
+        };
+    }
+
+    private static ChatLanguageModel failingModel() {
+        return new ChatLanguageModel() {
+            @Override
+            public Response<AiMessage> generate(List<ChatMessage> messages) {
+                throw new RuntimeException("Connection refused");
+            }
+        };
+    }
+
+    @Test
+    public void handleUnknownInput_keywordMatch_returnsUsage() {
+        NaturalLanguageParser parser = new NaturalLanguageParser();
+        String result = parser.handleUnknownInput("how to add a student");
+        assertTrue(result.contains("add"));
+    }
+
+    @Test
+    public void handleUnknownInput_noKeywordNoGemini_returnsFallback() {
+        NaturalLanguageParser parser = new NaturalLanguageParser();
+        String result = parser.handleUnknownInput("what is quantum physics");
+        assertTrue(result.contains("help"));
+    }
+
+    @Test
+    public void handleUnknownInput_withGemini_callsGemini() {
+        NaturalLanguageParser parser = new NaturalLanguageParser(
+                new KeywordMatcher(), stubModel("Use the add command"));
+        String result = parser.handleUnknownInput("what is quantum physics");
+        assertEquals("Use the add command", result);
+    }
+
+    @Test
+    public void handleUnknownInput_geminiKeywordMatchFirst_returnsKeyword() {
+        NaturalLanguageParser parser = new NaturalLanguageParser(
+                new KeywordMatcher(), stubModel("Gemini response"));
+        // "add" should match keyword first, not call Gemini
+        String result = parser.handleUnknownInput("how to add");
+        assertTrue(result.contains("add"));
+        assertFalse(result.equals("Gemini response"));
+    }
+
+    @Test
+    public void handleUnknownInput_geminiError_returnsFallback() {
+        NaturalLanguageParser parser = new NaturalLanguageParser(
+                new KeywordMatcher(), failingModel());
+        String result = parser.handleUnknownInput("something random");
+        assertTrue(result.contains("help"));
+    }
+
+    @Test
+    public void isGeminiAvailable_noModel_returnsFalse() {
+        NaturalLanguageParser parser = new NaturalLanguageParser();
+        assertFalse(parser.isGeminiAvailable());
+    }
+
+    @Test
+    public void isGeminiAvailable_withModel_returnsTrue() {
+        NaturalLanguageParser parser = new NaturalLanguageParser(
+                new KeywordMatcher(), stubModel("test"));
+        assertTrue(parser.isGeminiAvailable());
+    }
+
+    @Test
+    public void setGeminiApiKey_blank_clearsModel() {
+        NaturalLanguageParser parser = new NaturalLanguageParser(
+                new KeywordMatcher(), stubModel("test"));
+        assertTrue(parser.isGeminiAvailable());
+        parser.setGeminiApiKey("");
+        assertFalse(parser.isGeminiAvailable());
+    }
+}

--- a/src/test/java/seedu/coursepilot/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/coursepilot/logic/commands/AddCommandTest.java
@@ -230,6 +230,16 @@ public class AddCommandTest {
         public void addTutorial(Tutorial tutorial) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public String getGeminiApiKey() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGeminiApiKey(String apiKey) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add three-tier AI assistance for unknown commands: keyword matching → Gemini API → fallback
- Optional Google Gemini integration with API key configuration via AI Settings window
- Add `mac-aarch64` JavaFX classifiers for Apple Silicon compatibility
- Fix Path serialization in JsonUtil for LangChain4j Jackson module compatibility

## New files
- `logic/ai/KeywordMatcher.java` — keyword-to-usage response mapping
- `logic/ai/NaturalLanguageParser.java` — three-tier orchestrator with chat memory
- `logic/ai/ChatModelFactory.java` — Gemini model factory
- `ui/AiSettingsWindow.java` + FXML — API key configuration UI

## How to test

### Hint feature (keyword matching, no setup needed)
1. Run the app with `./gradlew run`
2. Type `how to add a student` → result display shows `add` command usage and syntax
3. Type `how to delete` → shows `delete` command usage
4. Type `how to search for someone` → shows `find` command usage
5. Type `how can I get started?` → shows a getting started guide
6. Type `show me all` → shows `list` command usage
7. Type something unrecognized like `asdfgh` → shows fallback: "Type 'help' to see available commands"

### Gemini AI (optional, requires API key)
1. Click menu bar → **AI** → **AI Settings**
2. Click the **Google AI Studio** link to get a free API key
3. Paste the key into the text field and click **Save**
4. Type a question like `how do I manage tutorials?` → Gemini responds in the result display
5. Ask a follow-up question → Gemini remembers context from previous questions

## Test plan
- [x] Unit tests for KeywordMatcher (8 tests)
- [x] Unit tests for NaturalLanguageParser (8 tests)
- [x] All 283 existing tests pass
- [ ] Manual: hint/keyword matching works as described above
- [ ] Manual: Gemini responds after configuring API key
- [ ] Manual: app works on Windows, macOS (Intel + ARM), Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)