### PR TITLE
Enhance help window with command reference

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -25,7 +25,8 @@ You can reach us at the email `seer[at]comp.nus.edu.sg`
 
 [[github](http://github.com/jyc300564)]
 
-* Role: Developer
+* Role: Team Lead
+* Responsibilities: UI
 
 ### Teh Ming Wei
 

--- a/src/main/java/seedu/coursepilot/ui/HelpWindow.java
+++ b/src/main/java/seedu/coursepilot/ui/HelpWindow.java
@@ -18,6 +18,40 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String USERGUIDE_URL = "https://ay2526s2-cs2103t-w13-4.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
+    public static final String COMMAND_REFERENCE = String.join("\n",
+            "GETTING STARTED",
+            "  select CS2103T-W12          Set the current working tutorial",
+            "  list -tutorial              List all tutorials (clears selection)",
+            "  list -student               List students in the selected tutorial",
+            "",
+            "MANAGING TUTORIALS",
+            "  add -tutorial /code CODE /day DAY /timeslot TIMESLOT /capacity CAP",
+            "    e.g. add -tutorial /code CS2103T-W12 /day Wed /timeslot 10am-11am /capacity 10",
+            "  delete -tutorial INDEX      Delete tutorial at INDEX in the list",
+            "",
+            "MANAGING STUDENTS (requires a tutorial to be selected first)",
+            "  add -student /name NAME /phone PHONE /email EMAIL /matric MATRIC [/tag TAG]...",
+            "    e.g. add -student /name John Doe /phone 98765432 /email johnd@example.com /matric A000000",
+            "  edit INDEX [/name NAME] [/phone PHONE] [/email EMAIL] [/matric MATRIC] [/tag TAG]...",
+            "    e.g. edit 1 /phone 91234567 /email johndoe@example.com",
+            "  delete -student INDEX       Delete student at INDEX from the tutorial",
+            "",
+            "FINDING STUDENTS (requires a tutorial to be selected first)",
+            "  find KEYWORD                Search by name (case-insensitive, substring match)",
+            "  find /phone KEYWORD         Search by phone number prefix",
+            "  find /email KEYWORD         Search by email (case-insensitive)",
+            "  find /matric KEYWORD        Search by matric number prefix",
+            "",
+            "OTHER COMMANDS",
+            "  clear                       Delete all students and tutorials",
+            "  help                        Show this help window",
+            "  exit                        Exit the application",
+            "",
+            "TIPS",
+            "  - Parameters can be in any order",
+            "  - Use Tab to accept autocomplete suggestions, Esc to dismiss"
+    );
+
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
@@ -27,6 +61,9 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private Label helpMessage;
 
+    @FXML
+    private Label commandReference;
+
     /**
      * Creates a new HelpWindow.
      *
@@ -35,6 +72,7 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
+        commandReference.setText(COMMAND_REFERENCE);
     }
 
     /**

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,8 +1,36 @@
-#copyButton, #helpMessage {
-    -fx-text-fill: white;
+.help-window-root {
+    -fx-background-color: derive(#1d1d1d, 20%);
+}
+
+.help-title {
+    -fx-text-fill: #e0e0e0;
+    -fx-font-size: 18px;
+    -fx-font-weight: bold;
+}
+
+.help-scroll-pane {
+    -fx-background: derive(#1d1d1d, 30%);
+    -fx-background-color: derive(#1d1d1d, 30%);
+}
+
+.help-scroll-pane .viewport {
+    -fx-background-color: derive(#1d1d1d, 30%);
+}
+
+.help-content {
+    -fx-text-fill: #cccccc;
+    -fx-font-family: "Monospace";
+    -fx-font-size: 13px;
+    -fx-padding: 10;
+}
+
+.help-url {
+    -fx-text-fill: #90caf9;
+    -fx-font-size: 13px;
 }
 
 #copyButton {
+    -fx-text-fill: white;
     -fx-background-color: dimgray;
 }
 
@@ -12,8 +40,4 @@
 
 #copyButton:armed {
     -fx-background-color: darkgray;
-}
-
-#helpMessageContainer {
-    -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -5,11 +5,14 @@
 <?import javafx.scene.Scene?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="true" title="Help" type="javafx.stage.Stage" minWidth="600" minHeight="400"
+         xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -19,26 +22,27 @@
         <URL value="@HelpWindow.css" />
       </stylesheets>
 
-      <HBox alignment="CENTER" fx:id="helpMessageContainer">
-        <children>
-          <Label fx:id="helpMessage" text="Label">
-            <HBox.margin>
-              <Insets right="5.0" />
-            </HBox.margin>
-          </Label>
-          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
-            <HBox.margin>
-              <Insets left="5.0" />
-            </HBox.margin>
-          </Button>
-        </children>
-        <opaqueInsets>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </opaqueInsets>
+      <VBox fx:id="helpWindowRoot" spacing="10" styleClass="help-window-root">
         <padding>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+          <Insets bottom="15.0" left="15.0" right="15.0" top="15.0" />
         </padding>
-      </HBox>
+        <children>
+          <Label fx:id="helpTitle" text="CoursePilot Command Reference" styleClass="help-title" />
+
+          <ScrollPane fitToWidth="true" VBox.vgrow="ALWAYS" styleClass="help-scroll-pane">
+            <content>
+              <Label fx:id="commandReference" wrapText="true" styleClass="help-content" />
+            </content>
+          </ScrollPane>
+
+          <HBox alignment="CENTER_LEFT" spacing="10">
+            <children>
+              <Label fx:id="helpMessage" text="Label" styleClass="help-url" HBox.hgrow="ALWAYS" />
+              <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL" />
+            </children>
+          </HBox>
+        </children>
+      </VBox>
     </Scene>
   </scene>
 </fx:root>


### PR DESCRIPTION
## Summary
- Replace the minimal help window (URL-only) with a scrollable command reference grouped by category (Getting Started, Tutorials, Students, Find, Other)
- Keep the "Copy URL" button so users can quickly copy the full User Guide link to clipboard
- Window is now resizable with a dark theme consistent with the app

## Test plan
- [ ] Run `help` command and verify the help window shows the command reference
- [ ] Verify all listed commands match the current feature set
- [ ] Click "Copy URL" and paste to verify the UG URL is copied correctly
- [ ] Resize the help window and verify scrolling works
- [ ] Verify the window renders correctly at 1920x1080 and 1280x720

🤖 Generated with [Claude Code](https://claude.com/claude-code)