### PR TITLE
[PE-D] Bug fix for incorrect `FindCommandParser` input validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'coursepilot.jar'
+    archiveFileName = 'CoursePilot.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/coursepilot/MainApp.java
+++ b/src/main/java/seedu/coursepilot/MainApp.java
@@ -36,7 +36,7 @@ import seedu.coursepilot.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 5, 1, true);
+    public static final Version VERSION = new Version(1, 6, 1, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/coursepilot/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/coursepilot/logic/parser/FindCommandParser.java
@@ -8,8 +8,11 @@ import java.util.Arrays;
 import seedu.coursepilot.logic.commands.FindCommand;
 import seedu.coursepilot.logic.parser.exceptions.ParseException;
 import seedu.coursepilot.model.student.EmailContainsKeywordsPredicate;
+import seedu.coursepilot.model.student.MatricNumber;
 import seedu.coursepilot.model.student.MatricNumberStartsWithKeywordsPredicate;
+import seedu.coursepilot.model.student.Name;
 import seedu.coursepilot.model.student.NameContainsKeywordsPredicate;
+import seedu.coursepilot.model.student.Phone;
 import seedu.coursepilot.model.student.PhoneStartsWithKeywordsPredicate;
 
 /**
@@ -51,10 +54,20 @@ public class FindCommandParser implements Parser<FindCommand> {
 
             switch (flag) {
             case PHONE:
+                for (String kw : keywords) {
+                    if (!Phone.isValidPhone(kw)) {
+                        throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+                    }
+                }
                 return new FindCommand(new PhoneStartsWithKeywordsPredicate(Arrays.asList(keywords)));
             case EMAIL:
                 return new FindCommand(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
             case MATRIC:
+                for (String kw : keywords) {
+                    if (!MatricNumber.isValidMatricNumber(kw)) {
+                        throw new ParseException(MatricNumber.MESSAGE_CONSTRAINTS);
+                    }
+                }
                 return new FindCommand(new MatricNumberStartsWithKeywordsPredicate(Arrays.asList(keywords)));
             default:
                 // Default case only occurs if you added a flag into FindCommand.Flag but did not add the case here
@@ -62,7 +75,11 @@ public class FindCommandParser implements Parser<FindCommand> {
                 throw new AssertionError("Unhandled flag: " + flag);
             }
         }
-
+        for (String token : tokens) {
+            if (!Name.isValidName(token)) {
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            }
+        }
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(tokens)));
     }
 }

--- a/src/main/java/seedu/coursepilot/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/coursepilot/logic/parser/FindCommandParser.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import seedu.coursepilot.logic.commands.FindCommand;
 import seedu.coursepilot.logic.parser.exceptions.ParseException;
 import seedu.coursepilot.model.student.EmailContainsKeywordsPredicate;
-import seedu.coursepilot.model.student.MatricNumber;
 import seedu.coursepilot.model.student.MatricNumberStartsWithKeywordsPredicate;
 import seedu.coursepilot.model.student.Name;
 import seedu.coursepilot.model.student.NameContainsKeywordsPredicate;

--- a/src/main/java/seedu/coursepilot/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/coursepilot/logic/parser/FindCommandParser.java
@@ -63,11 +63,6 @@ public class FindCommandParser implements Parser<FindCommand> {
             case EMAIL:
                 return new FindCommand(new EmailContainsKeywordsPredicate(Arrays.asList(keywords)));
             case MATRIC:
-                for (String kw : keywords) {
-                    if (!MatricNumber.isValidMatricNumber(kw)) {
-                        throw new ParseException(MatricNumber.MESSAGE_CONSTRAINTS);
-                    }
-                }
                 return new FindCommand(new MatricNumberStartsWithKeywordsPredicate(Arrays.asList(keywords)));
             default:
                 // Default case only occurs if you added a flag into FindCommand.Flag but did not add the case here


### PR DESCRIPTION
Fix #229
Fix #234
Fix #241
Fix #245

Issue #229 Fix: Ensure that `FindCommandParser` validates input for `Name`
Issue #234 and #245 Fix: Ensure that `FindCommandParser` validates input for `Phone`
Issue #241 Fix: Ensure that `FindCommandParser` validates input for `MatricNumber`

Steps to test:
`find 87` Should fail as names cannot contain numbers. Only letters
`find /phone abc` Should fail as it is not a number
`find /phone 1234512345123451234512345` Should fail as it exceeds 15 digits
`find /matric ABCDEFGHIJK` Should fail as this does not follow the `AXXXXXX` format.