### PR TITLE
fix: resolve delete student against filtered list (#246)

### DIFF
--- a/src/main/java/seedu/coursepilot/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/coursepilot/logic/commands/DeleteCommand.java
@@ -61,13 +61,13 @@ public class DeleteCommand extends Command {
             }
 
             Tutorial currentTutorial = currentTutorialOpt.get();
-            List<Student> tutorialStudents = currentTutorial.getStudents();
+            List<Student> displayedStudents = model.getFilteredStudentList();
 
-            if (targetIndex.getZeroBased() >= tutorialStudents.size()) {
+            if (targetIndex.getZeroBased() >= displayedStudents.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
             }
 
-            Student studentToDelete = tutorialStudents.get(targetIndex.getZeroBased());
+            Student studentToDelete = displayedStudents.get(targetIndex.getZeroBased());
 
             if (!currentTutorial.hasStudent(studentToDelete)) {
                 throw new CommandException(MESSAGE_STUDENT_NOT_IN_TUTORIAL);

--- a/src/test/java/seedu/coursepilot/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/coursepilot/logic/commands/DeleteCommandTest.java
@@ -96,6 +96,42 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void executeAfterFindFilter_validIndex_success() throws CommandException {
+        Tutorial tutorial = model.getFilteredTutorialList().get(0);
+        model.setCurrentOperatingTutorial(tutorial);
+
+        // Simulate `find` narrowing the displayed student list to only "Daniel Meier".
+        Student expectedTarget = tutorial.getStudents().stream()
+                .filter(s -> s.getName().fullName.equals("Daniel Meier"))
+                .findFirst()
+                .orElseThrow();
+        model.updateFilteredStudentList(s -> s.equals(expectedTarget));
+        assertEquals(1, model.getFilteredStudentList().size());
+
+        // User sees one student at displayed index 1 and expects that exact student to be deleted.
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_STUDENT, "student");
+        CommandResult result = deleteCommand.execute(model);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_STUDENT_SUCCESS,
+                Messages.format(expectedTarget));
+        assertEquals(expectedMessage, result.getFeedbackToUser());
+        assertFalse(tutorial.hasStudent(expectedTarget));
+    }
+
+    @Test
+    public void executeAfterFindFilter_outOfRange_throwsException() {
+        Tutorial tutorial = model.getFilteredTutorialList().get(0);
+        model.setCurrentOperatingTutorial(tutorial);
+
+        // Filter down to a single student; index 2 must be rejected against the filtered list size.
+        Student onlyMatch = tutorial.getStudents().get(0);
+        model.updateFilteredStudentList(s -> s.equals(onlyMatch));
+
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_SECOND_STUDENT, "student");
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_STUDENT, "student");
         DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_STUDENT, "student");


### PR DESCRIPTION
Closes #246.

## Summary
After running `find` with a selected tutorial, `DeleteCommand` still indexed into `currentTutorial.getStudents()` (the unfiltered list), which did not match the indices the user sees in the UI. Deleting by displayed index could silently remove the wrong student.

This change resolves the target from `model.getFilteredStudentList()` instead, so the displayed index always maps to the displayed student. Membership in the current tutorial is still verified before removal.

## Test plan
- [x] New `executeAfterFindFilter_validIndex_success` — filters to one student and verifies that student is the one deleted.
- [x] New `executeAfterFindFilter_outOfRange_throwsException` — verifies an index past the filtered size throws `MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX`.
- [x] Existing `DeleteCommandTest` cases still pass.
- [x] `./gradlew checkstyleMain checkstyleTest` clean.