### PR TITLE
fix: allow linking existing student across tutorials (#247, #239)

### DIFF
--- a/src/main/java/seedu/coursepilot/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/coursepilot/logic/commands/AddCommand.java
@@ -56,14 +56,16 @@ public class AddCommand extends Command {
             + PREFIX_CAPACITY + " 10 ";
 
     public static final String MESSAGE_SUCCESS_STUDENT = "Added student: %1$s";
+    public static final String MESSAGE_LINKED_EXISTING_STUDENT =
+            "Linked existing student to tutorial: %1$s\n"
+            + "(Matric number matched an existing record, so the stored details were used. "
+            + "Use the edit command to update them.)";
     public static final String MESSAGE_SUCCESS_TUTORIAL = "Added tutorial: %1$s";
     public static final String MESSAGE_DUPLICATE_STUDENT =
-            "This student or matriculation number already exists in CoursePilot.";
+            "This student is already in the current tutorial.";
     public static final String MESSAGE_DUPLICATE_CONTACT_DETAIL =
             "Another student with the same phone number or email"
             + " already exists in CoursePilot.";
-    public static final String MESSAGE_DUPLICATE_STUDENT_MATRIC =
-            "A different student with this matriculation number already exists.";
     public static final String MESSAGE_DUPLICATE_TUTORIAL =
             "This tutorial code already exists in CoursePilot";
     public static final String MESSAGE_NO_CURRENT_OPERATING_TUTORIAL =
@@ -120,16 +122,11 @@ public class AddCommand extends Command {
                     .filter(storedStudent -> storedStudent.isSameStudent(toAdd))
                     .findFirst();
 
-            if (existingStudent.isPresent() && !existingStudent.get().equals(toAdd)) {
-                throw new CommandException(MESSAGE_DUPLICATE_STUDENT_MATRIC);
-            }
-
             Student studentToAddToTutorial = existingStudent.orElse(toAdd);
 
             if (existingStudent.isEmpty() && model.getCoursePilot().getStudentList().stream()
-                    .anyMatch(storedStudent -> !storedStudent.isSameStudent(toAdd)
-                        && (storedStudent.getPhone().equals(toAdd.getPhone())
-                            || storedStudent.getEmail().equals(toAdd.getEmail())))) {
+                    .anyMatch(storedStudent -> storedStudent.getPhone().equals(toAdd.getPhone())
+                            || storedStudent.getEmail().equals(toAdd.getEmail()))) {
                 throw new CommandException(MESSAGE_DUPLICATE_CONTACT_DETAIL);
             }
 
@@ -147,8 +144,10 @@ public class AddCommand extends Command {
 
             currentOperatingTutorial.addStudent(studentToAddToTutorial);
             model.updateFilteredStudentList(currentOperatingTutorial::hasStudent);
-            return new CommandResult(
-                    String.format(MESSAGE_SUCCESS_STUDENT, Messages.format(studentToAddToTutorial)));
+
+            boolean linkedExisting = existingStudent.isPresent() && !existingStudent.get().equals(toAdd);
+            String template = linkedExisting ? MESSAGE_LINKED_EXISTING_STUDENT : MESSAGE_SUCCESS_STUDENT;
+            return new CommandResult(String.format(template, Messages.format(studentToAddToTutorial)));
         }
         if (addTarget == AddTarget.TUTORIAL) {
             if (model.hasTutorial(tutorialToAdd)) {

--- a/src/test/java/seedu/coursepilot/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/coursepilot/logic/commands/AddCommandIntegrationTest.java
@@ -64,7 +64,7 @@ public class AddCommandIntegrationTest {
         model.getCurrentOperatingTutorial().get().addStudent(validStudent);
 
         assertCommandFailure(new AddCommand(duplicateStudent), model,
-                AddCommand.MESSAGE_DUPLICATE_STUDENT_MATRIC);
+                AddCommand.MESSAGE_DUPLICATE_STUDENT);
     }
 
     @Test

--- a/src/test/java/seedu/coursepilot/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/coursepilot/logic/commands/AddCommandTest.java
@@ -59,7 +59,7 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_duplicateStudent_throwsCommandException() {
+    public void execute_duplicateStudentInTutorial_throwsCommandException() {
         Student validStudent = new StudentBuilder().build();
         Student duplicateStudent = new StudentBuilder().altContactBuild();
         AddCommand addCommand = new AddCommand(duplicateStudent);
@@ -70,23 +70,32 @@ public class AddCommandTest {
         modelStub.setCurrentOperatingTutorial(tutorial);
 
         assertThrows(
-            CommandException.class, AddCommand.MESSAGE_DUPLICATE_STUDENT_MATRIC, () -> addCommand.execute(modelStub));
+            CommandException.class, AddCommand.MESSAGE_DUPLICATE_STUDENT, () -> addCommand.execute(modelStub));
     }
 
     @Test
-    public void execute_duplicateMatricNumber_throwsCommandException() {
-        Student alice = new StudentBuilder(ALICE).build();
-        Student bobWithAliceMatric = new StudentBuilder(BOB)
-                .withMatriculationNumber(ALICE.getMatriculationNumber().matricNumber).build();
-        AddCommand addCommand = new AddCommand(bobWithAliceMatric);
-        ModelStubWithStudent modelStub = new ModelStubWithStudent(alice);
-        Tutorial tutorial = new Tutorial(new TutorialCode("T01"), new Day("Mon"),
-                new TimeSlot("13:00-14:00"), new Capacity(20));
-        tutorial.addStudent(alice);
-        modelStub.setCurrentOperatingTutorial(tutorial);
+    public void execute_existingStudentInDifferentTutorial_linkedSuccessfully() throws CommandException {
+        Model model = new ModelManager(TypicalStudents.getTypicalCoursePilot(), new UserPrefs());
+        Tutorial tutorial2 = new Tutorial(new TutorialCode("CS2103T-T01"), new Day("Thu"),
+                new TimeSlot("14:00-15:00"), new Capacity(10));
+        model.addTutorial(tutorial2);
+        model.setCurrentOperatingTutorial(tutorial2);
 
-        assertThrows(
-            CommandException.class, AddCommand.MESSAGE_DUPLICATE_STUDENT_MATRIC, () -> addCommand.execute(modelStub));
+        // Caller-supplied student shares Alice's matric but has different phone/email/tags.
+        Student aliceWithDifferentDetails = new StudentBuilder(ALICE)
+                .withPhone("99990000")
+                .withEmail("alice.alt@example.com")
+                .withTags("newTag")
+                .build();
+
+        CommandResult result = new AddCommand(aliceWithDifferentDetails).execute(model);
+
+        String expected = String.format(AddCommand.MESSAGE_LINKED_EXISTING_STUDENT, Messages.format(ALICE));
+        assertEquals(expected, result.getFeedbackToUser());
+        assertTrue(tutorial2.hasStudent(ALICE));
+        // The original Alice record is unchanged; no alternate Alice exists.
+        assertTrue(model.hasStudent(ALICE));
+        assertFalse(model.getCoursePilot().getStudentList().contains(aliceWithDifferentDetails));
     }
 
     @Test
@@ -144,7 +153,7 @@ public class AddCommandTest {
                 .build();
 
         assertThrows(CommandException.class,
-                AddCommand.MESSAGE_DUPLICATE_STUDENT_MATRIC, () -> new AddCommand(modifiedAlicePayload).execute(model));
+                AddCommand.MESSAGE_DUPLICATE_STUDENT, () -> new AddCommand(modifiedAlicePayload).execute(model));
     }
 
     @Test


### PR DESCRIPTION
Closes #247.
Closes #239.

## Summary
Previously, `AddCommand` rejected any add whose matric matched an existing student but whose other fields differed, with `MESSAGE_DUPLICATE_STUDENT_MATRIC`. This meant a student already in one tutorial could not be added to a second tutorial unless the caller re-entered every field byte-for-byte, including the exact tag set — contradicting the UG promise of multi-tutorial linking.

Treat the matriculation number as the student's identity:
- if the student is already in the current tutorial, fail with the clearer `MESSAGE_DUPLICATE_STUDENT` (\"already in this tutorial\");
- otherwise, link the stored record into the current tutorial and return `MESSAGE_LINKED_EXISTING_STUDENT`, which surfaces that the stored details were used and points the user at `edit` for updates.

`MESSAGE_DUPLICATE_STUDENT_MATRIC` is removed; two affected tests are updated to expect the new behaviour, and a new test covers the linked-existing-student flow.

## Test plan
- [x] `AddCommandTest#execute_existingStudentInDifferentTutorial_linkedSuccessfully` — existing Alice linked to new tutorial even with different phone/email/tags; stored record unchanged.
- [x] `AddCommandTest#execute_duplicateStudentInTutorial_throwsCommandException` — same-matric add into same tutorial still rejected, now with the clearer message.
- [x] `AddCommandTest#execute_existingStudentAlreadyInCurrentTutorial_throwsCommandException` — updated to expect `MESSAGE_DUPLICATE_STUDENT`.
- [x] `AddCommandIntegrationTest#execute_duplicateStudent_throwsCommandException` — updated similarly.
- [x] `./gradlew checkstyleMain checkstyleTest` clean.
- [x] Full suite: 359 tests pass (one pre-existing `AppUtilTest` env failure unrelated to this change).