### PR TITLE
fix: reject tutorials that overlap an existing tutorial (#271, #248)

### DIFF
--- a/src/main/java/seedu/coursepilot/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/coursepilot/logic/commands/AddCommand.java
@@ -66,6 +66,9 @@ public class AddCommand extends Command {
             "A different student with this matriculation number already exists.";
     public static final String MESSAGE_DUPLICATE_TUTORIAL =
             "This tutorial code already exists in CoursePilot";
+    public static final String MESSAGE_TUTORIAL_OVERLAP =
+            "This tutorial overlaps with an existing tutorial: %1$s."
+            + " A tutor cannot run two tutorials at the same time.";
     public static final String MESSAGE_NO_CURRENT_OPERATING_TUTORIAL =
             "No tutorial selected. Please select a tutorial to operate on first.";
     public static final String MESSAGE_TUTORIAL_FULL =
@@ -153,6 +156,13 @@ public class AddCommand extends Command {
         if (addTarget == AddTarget.TUTORIAL) {
             if (model.hasTutorial(tutorialToAdd)) {
                 throw new CommandException(MESSAGE_DUPLICATE_TUTORIAL);
+            }
+            Optional<Tutorial> conflict = model.getCoursePilot().getTutorialList().stream()
+                    .filter(tutorialToAdd::overlapsWith)
+                    .findFirst();
+            if (conflict.isPresent()) {
+                throw new CommandException(
+                        String.format(MESSAGE_TUTORIAL_OVERLAP, conflict.get().getTutorialCode()));
             }
             model.addTutorial(tutorialToAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS_TUTORIAL, Messages.format(tutorialToAdd)));

--- a/src/main/java/seedu/coursepilot/model/tutorial/TimeSlot.java
+++ b/src/main/java/seedu/coursepilot/model/tutorial/TimeSlot.java
@@ -49,6 +49,30 @@ public class TimeSlot {
         return start.isBefore(end);
     }
 
+    /**
+     * Returns the start time of this slot.
+     */
+    public LocalTime getStartTime() {
+        return LocalTime.parse(value.split("-")[0]);
+    }
+
+    /**
+     * Returns the end time of this slot.
+     */
+    public LocalTime getEndTime() {
+        return LocalTime.parse(value.split("-")[1]);
+    }
+
+    /**
+     * Returns true if this time slot overlaps with {@code other}.
+     * Slots that merely touch at a boundary (e.g. 10:00-11:00 and 11:00-12:00) do not overlap.
+     */
+    public boolean overlapsWith(TimeSlot other) {
+        requireNonNull(other);
+        return getStartTime().isBefore(other.getEndTime())
+                && other.getStartTime().isBefore(getEndTime());
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/coursepilot/model/tutorial/Tutorial.java
+++ b/src/main/java/seedu/coursepilot/model/tutorial/Tutorial.java
@@ -146,6 +146,18 @@ public class Tutorial {
     }
 
     /**
+     * Returns true if this tutorial overlaps with {@code other} (same day, overlapping time range).
+     * A tutorial never overlaps with itself.
+     */
+    public boolean overlapsWith(Tutorial other) {
+        requireNonNull(other);
+        if (isSameTutorial(other)) {
+            return false;
+        }
+        return this.day.equals(other.day) && this.timeSlot.overlapsWith(other.timeSlot);
+    }
+
+    /**
      * Returns true if both tutorials have the same fields.
      */
     @Override

--- a/src/test/java/seedu/coursepilot/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/coursepilot/logic/commands/AddCommandIntegrationTest.java
@@ -68,6 +68,48 @@ public class AddCommandIntegrationTest {
     }
 
     @Test
+    public void execute_addOverlappingTutorial_throwsCommandException() {
+        Tutorial existing = model.getCurrentOperatingTutorial().get();
+        // Same day + strictly overlapping window -> must be rejected.
+        Tutorial overlapping = new Tutorial(new TutorialCode("CS2103T-CLASH"),
+                new Day(existing.getDay()),
+                new TimeSlot(overlappingTimeSlot(existing.getTimeSlot())),
+                new Capacity(10));
+        String expected = String.format(AddCommand.MESSAGE_TUTORIAL_OVERLAP, existing.getTutorialCode());
+        assertCommandFailure(new AddCommand(overlapping), model, expected);
+    }
+
+    @Test
+    public void execute_addBackToBackTutorial_success() {
+        Tutorial existing = model.getCurrentOperatingTutorial().get();
+        // Touching boundary but not overlapping (end == start) -> allowed.
+        Tutorial backToBack = new Tutorial(new TutorialCode("CS2103T-BTB"),
+                new Day(existing.getDay()),
+                new TimeSlot(backToBackTimeSlot(existing.getTimeSlot())),
+                new Capacity(10));
+        Model expectedModel = new ModelManager(model.getCoursePilot(), new UserPrefs());
+        expectedModel.setCurrentOperatingTutorial(expectedModel.getFilteredTutorialList().get(0));
+        expectedModel.addTutorial(backToBack);
+        assertCommandSuccess(new AddCommand(backToBack), model,
+                String.format(AddCommand.MESSAGE_SUCCESS_TUTORIAL, Messages.format(backToBack)),
+                expectedModel);
+    }
+
+    private static String overlappingTimeSlot(String existing) {
+        // "13:00-14:00" -> "13:30-14:30"
+        String[] parts = existing.split("-");
+        int startHour = Integer.parseInt(parts[0].substring(0, 2));
+        return String.format("%02d:30-%02d:30", startHour, startHour + 1);
+    }
+
+    private static String backToBackTimeSlot(String existing) {
+        // "13:00-14:00" -> "14:00-15:00"
+        String[] parts = existing.split("-");
+        int endHour = Integer.parseInt(parts[1].substring(0, 2));
+        return String.format("%02d:00-%02d:00", endHour, endHour + 1);
+    }
+
+    @Test
     public void execute_tutorialAtCapacity_throwsCommandExceptionAndStateUnchanged() {
         Tutorial fullTutorial = new Tutorial(new TutorialCode("CS2103T-FULL"), new Day("Thu"),
                 new TimeSlot("14:00-15:00"), new Capacity(1));


### PR DESCRIPTION
Closes #271.
Closes #248.

## Summary
The app models a single tutor's schedule, so two tutorials can never run at the same time. Previously `AddCommand` accepted any new tutorial as long as its code was unique, which let a tutor double-book themselves (#248) and made it possible for the same student to end up in overlapping tutorials (#271).

- `TimeSlot.overlapsWith` compares parsed start/end times. Touching boundaries (10:00-11:00 vs 11:00-12:00) are NOT treated as overlap.
- `Tutorial.overlapsWith` returns true only when the day matches AND time slots overlap; a tutorial never overlaps with itself.
- `AddCommand`'s tutorial branch now scans the full tutorial list before accepting, rejecting with a message that names the conflicting tutorial code.

## Test plan
- [x] `AddCommandIntegrationTest#execute_addOverlappingTutorial_throwsCommandException` — same-day strict overlap rejected with `MESSAGE_TUTORIAL_OVERLAP`.
- [x] `AddCommandIntegrationTest#execute_addBackToBackTutorial_success` — back-to-back slot (end == start) allowed.
- [x] `./gradlew checkstyleMain checkstyleTest` clean.
- [x] Full suite: 361 tests pass (one pre-existing `AppUtilTest` env failure unrelated).