### PR TITLE
fix: require selected tutorial for edit command (#256)

### DIFF
--- a/src/main/java/seedu/coursepilot/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/coursepilot/logic/commands/EditCommand.java
@@ -56,6 +56,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_DUPLICATE_CONTACT_DETAIL =
             "Another student with the same phone number or email"
             + " already exists in CoursePilot.";
+    public static final String MESSAGE_NO_CURRENT_OPERATING_TUTORIAL =
+            "No tutorial selected. Please select a tutorial to operate on first.";
 
     private final Index index;
     private final EditStudentDescriptor editStudentDescriptor;
@@ -86,6 +88,11 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.getCurrentOperatingTutorial().isEmpty()) {
+            throw new CommandException(MESSAGE_NO_CURRENT_OPERATING_TUTORIAL);
+        }
+
         List<Student> lastShownList = model.getFilteredStudentList();
 
         if (index.getZeroBased() >= lastShownList.size()) {

--- a/src/test/java/seedu/coursepilot/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/coursepilot/logic/commands/EditCommandTest.java
@@ -15,6 +15,7 @@ import static seedu.coursepilot.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.coursepilot.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
 import static seedu.coursepilot.testutil.TypicalStudents.getTypicalCoursePilot;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.coursepilot.commons.core.index.Index;
@@ -34,7 +35,28 @@ import seedu.coursepilot.testutil.StudentBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalCoursePilot(), new UserPrefs());
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalCoursePilot(), new UserPrefs());
+        selectFirstTutorial(model);
+    }
+
+    private static void selectFirstTutorial(Model m) {
+        Tutorial t = m.getFilteredTutorialList().get(0);
+        m.setCurrentOperatingTutorial(t);
+        m.updateFilteredStudentList(t::hasStudent);
+    }
+
+    /** Mirrors what {@link EditCommand#execute(Model)} mutates so expectedModel can match. */
+    private static void simulateEdit(Model m, Student original, Student edited) {
+        String oldMatric = original.getMatriculationNumber().toString();
+        m.getCoursePilot().getTutorialList().forEach(t -> t.editStudent(oldMatric, edited));
+        m.setStudent(original, edited);
+        Tutorial selected = m.getCurrentOperatingTutorial().get();
+        m.updateFilteredStudentList(selected::hasStudent);
+    }
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -46,7 +68,8 @@ public class EditCommandTest {
             EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, Messages.format(editedStudent));
 
         Model expectedModel = new ModelManager(new CoursePilot(model.getCoursePilot()), new UserPrefs());
-        expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
+        selectFirstTutorial(expectedModel);
+        simulateEdit(expectedModel, model.getFilteredStudentList().get(0), editedStudent);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -68,7 +91,8 @@ public class EditCommandTest {
             EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, Messages.format(editedStudent));
 
         Model expectedModel = new ModelManager(new CoursePilot(model.getCoursePilot()), new UserPrefs());
-        expectedModel.setStudent(lastStudent, editedStudent);
+        selectFirstTutorial(expectedModel);
+        simulateEdit(expectedModel, lastStudent, editedStudent);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -82,6 +106,7 @@ public class EditCommandTest {
             EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, Messages.format(editedStudent));
 
         Model expectedModel = new ModelManager(new CoursePilot(model.getCoursePilot()), new UserPrefs());
+        selectFirstTutorial(expectedModel);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -99,7 +124,8 @@ public class EditCommandTest {
             EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, Messages.format(editedStudent));
 
         Model expectedModel = new ModelManager(new CoursePilot(model.getCoursePilot()), new UserPrefs());
-        expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
+        selectFirstTutorial(expectedModel);
+        simulateEdit(expectedModel, model.getFilteredStudentList().get(0), editedStudent);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -186,7 +212,8 @@ public class EditCommandTest {
             EditCommand.MESSAGE_EDIT_STUDENT_SUCCESS, Messages.format(editedStudent));
 
         Model expectedModel = new ModelManager(new CoursePilot(model.getCoursePilot()), new UserPrefs());
-        expectedModel.setStudent(studentToEdit, editedStudent);
+        selectFirstTutorial(expectedModel);
+        simulateEdit(expectedModel, studentToEdit, editedStudent);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
 
@@ -195,6 +222,14 @@ public class EditCommandTest {
             .anyMatch(student -> student.getMatriculationNumber().toString().equals(oldMatric)));
         assertTrue(tutorial.getStudents().stream()
             .anyMatch(student -> student.getMatriculationNumber().toString().equals(newMatric)));
+    }
+
+    @Test
+    public void execute_noCurrentOperatingTutorial_throwsCommandException() {
+        Model bareModel = new ModelManager(getTypicalCoursePilot(), new UserPrefs());
+        EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_STUDENT, descriptor);
+        assertCommandFailure(editCommand, bareModel, EditCommand.MESSAGE_NO_CURRENT_OPERATING_TUTORIAL);
     }
 
     @Test


### PR DESCRIPTION
Closes #256.

## Summary
`AddCommand` and `DeleteCommand` both refuse to operate on a student when no tutorial is selected, but `EditCommand` silently ran against the global student list. This was inconsistent and let users mutate records they could not see in the current view.

Adds the same `MESSAGE_NO_CURRENT_OPERATING_TUTORIAL` guard to `EditCommand` so all three student-mutating commands behave the same.

`EditCommandTest` is refactored to set a current operating tutorial in `@BeforeEach` via a `selectFirstTutorial` helper, and a `simulateEdit` helper mirrors what `EditCommand` mutates so `expectedModel` matches `actualModel` under the new tutorial-scoped filter.

## Test plan
- [x] New `execute_noCurrentOperatingTutorial_throwsCommandException` covers the new failure path.
- [x] Existing success/failure tests updated to use the new helpers and still pass.
- [x] `./gradlew checkstyleMain checkstyleTest` clean.
- [x] Full suite: 360 tests pass (one pre-existing `AppUtilTest` env failure unrelated).