### PR TITLE
fix: surface invalid-index error for delete command (#227, #228)

### DIFF
--- a/src/main/java/seedu/coursepilot/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/coursepilot/logic/parser/DeleteCommandParser.java
@@ -18,28 +18,22 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
 
     public DeleteCommand parse(String args) throws ParseException {
-        try {
-            String trimmedArgs = args.trim();
-            if (trimmedArgs.isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
-            String[] splitArgs = trimmedArgs.split("\\s+", 2);
-            String firstArg = splitArgs[0];
-            String remainingArgs = splitArgs.length > 1 ? splitArgs[1].trim() : "";
-            if ("-student".equals(firstArg)) {
-                Index index = ParserUtil.parseIndex(remainingArgs);
-                // delete student to be done here (deletes from main list and all tutorials)
-                return new DeleteCommand(index, "student");
-            } else if ("-tutorial".equals(firstArg)) {
-                Index index = ParserUtil.parseIndex(remainingArgs);
-                return new DeleteCommand(index, "tutorial");
-            } else {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
-        } catch (ParseException pe) {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+        String[] splitArgs = trimmedArgs.split("\\s+", 2);
+        String firstArg = splitArgs[0];
+        String remainingArgs = splitArgs.length > 1 ? splitArgs[1].trim() : "";
+        if ("-student".equals(firstArg)) {
+            Index index = ParserUtil.parseIndex(remainingArgs);
+            return new DeleteCommand(index, "student");
+        } else if ("-tutorial".equals(firstArg)) {
+            Index index = ParserUtil.parseIndex(remainingArgs);
+            return new DeleteCommand(index, "tutorial");
+        } else {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/test/java/seedu/coursepilot/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/coursepilot/logic/parser/DeleteCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.coursepilot.logic.parser;
 import static seedu.coursepilot.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.coursepilot.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.coursepilot.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.coursepilot.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.coursepilot.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 
 import org.junit.jupiter.api.Test;
@@ -28,5 +29,15 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_zeroStudentIndex_throwsInvalidIndex() {
+        assertParseFailure(parser, " -student 0", MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_zeroTutorialIndex_throwsInvalidIndex() {
+        assertParseFailure(parser, " -tutorial 0", MESSAGE_INVALID_INDEX);
     }
 }


### PR DESCRIPTION
## Summary
- `delete -student 0` and `delete -tutorial 0` now correctly show "Index is not a non-zero unsigned integer" instead of the generic "Invalid command format" message
- Root cause: `DeleteCommandParser` had a catch-all that rewrapped every `ParseException` with `MESSAGE_INVALID_COMMAND_FORMAT`, masking the specific error from `ParserUtil.parseIndex`
- Added tests for zero-index inputs on both `-student` and `-tutorial`

## Test plan
- [x] `./gradlew checkstyleMain checkstyleTest` passes
- [x] `DeleteCommandParserTest` passes (including new zero-index tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)