### PR TITLE
docs: make Developer Guide NFRs measurable

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -611,12 +611,12 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 4.  Should not depend on any remote server.
 5.  Should not require a Database Management System (DBMS).
 6.  Should return search results within 2 second for 1000 stored students and 100 tutorial slots.
-7.  All commands should execute and display results within 2 seconds for typical data sizes.
+7.  All commands should execute and display results within 2 seconds when the system stores up to 1000 students and 100 tutorial slots.
 8.  Should launch and be ready to accept commands within 3 seconds under typical conditions.
 9.  Data should be stored locally in a human-editable file format (e.g., JSON).
 10. Should not lose any stored data when the application is closed normally via the `exit` commmand, and should persist data between sessions.
 11. Existing data should remain intact even if a command fails due to invalid input.
-12.  The GUI should work well for standard screen resolutions of 1920x1080 and higher at 100% and 125% scaling, and should be usable at 1280x720 and higher at 150% scaling.
+12.  At 1920x1080 and higher (100% and 125% scaling), and at 1280x720 and higher (150% scaling), the GUI should show all primary UI panels without overlapping components or truncated text, and all interactive controls should remain accessible without horizontal scrolling.
 
 ### Glossary
 


### PR DESCRIPTION
fix #272 
fix #273 

Clarify ambiguous NFR wording by replacing subjective terms with testable criteria.

Define command performance expectations for up to 1000 students and 100 tutorial slots. Replace work well with explicit UI acceptance criteria at stated resolutions and scaling: no overlap, no truncated text, and no horizontal scrolling needed to access controls.