### PR TITLE
fix(edit): correct usage message prefix-value spacing

### DIFF
--- a/src/main/java/seedu/coursepilot/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/coursepilot/logic/commands/EditCommand.java
@@ -40,14 +40,14 @@ public class EditCommand extends Command {
             + "by the index number used in the displayed student list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_MATRICNUMBER + "MATRICNUMBER] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_NAME + " NAME] "
+            + "[" + PREFIX_PHONE + " PHONE NUMBER] "
+            + "[" + PREFIX_EMAIL + " EMAIL] "
+            + "[" + PREFIX_MATRICNUMBER + " MATRICNUMBER] "
+            + "[" + PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_PHONE + " 91234567 "
+            + PREFIX_EMAIL + " johndoe@example.com";
 
     public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Edited student: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";


### PR DESCRIPTION
fix #264 

Update EditCommand usage text to avoid implying that prefixes and values are contiguous. The error/help format now shows:
edit INDEX [/name NAME] [/phone PHONE NUMBER] [/email EMAIL] [/matric MATRICNUMBER] [/tag TAG]... Also update the example command to include spaces after /phone and /email.